### PR TITLE
Set PL Root based on config.paths.pattern_lab

### DIFF
--- a/gulp-tasks/gulp-pattern-lab.js
+++ b/gulp-tasks/gulp-pattern-lab.js
@@ -11,7 +11,7 @@ const fs = require('fs');
       // eslint-disable-next-line comma-dangle
       fs.readFileSync(config.patternLab.configFile, 'utf8')
     );
-    const plRoot = path.join(config.patternLab.configFile, '../..');
+    const plRoot = path.join(config.paths.pattern_lab, '../');
     const plSource = path.join(plRoot, plConfig.sourceDir);
     const consolePath = path.join(plRoot, 'core/console');
 


### PR DESCRIPTION
Uses @evanmwillhite's suggestion to rely on the `config.paths.pattern_lab` variable to set `plRoot` correctly. `config.paths.pattern_lab` defaults to `/public` so this searches up a directory via `../`. 

Addresses #61